### PR TITLE
Fixed noise

### DIFF
--- a/hardware-level/rtl/controller_interface/rtl/controller.sv
+++ b/hardware-level/rtl/controller_interface/rtl/controller.sv
@@ -8,7 +8,7 @@ module controller_m #(
     parameter SYNC_LATCH = 1'b0
 ) (
     input [7:0] buttons_B,
-    input       clk,
+    input       clk_in,
     input       clk_in_enable,
     input       latch,
     output wire data_B
@@ -18,7 +18,7 @@ module controller_m #(
 
     generate if ( SYNC_LATCH ) begin
 
-        always_ff @ ( posedge clk ) if ( clk_in_enable ) begin
+        always_ff @ ( posedge clk_in ) if ( clk_in_enable ) begin
             if ( latch )
                 register <= buttons_B;
             else
@@ -34,7 +34,7 @@ module controller_m #(
                 register = buttons_B;
         end
 
-        always_ff @ ( posedge clk ) if ( clk_in_enable ) begin
+        always_ff @ ( posedge clk_in ) if ( clk_in_enable ) begin
             if ( !latch )
                 register = {register[6:0], 1'b0};
         end

--- a/hardware-level/rtl/gpu/rtl/background.sv
+++ b/hardware-level/rtl/gpu/rtl/background.sv
@@ -11,7 +11,8 @@
 
 
 module background_m (
-    input                           clk, // 12.5875 MHz
+    input                           clk_12_5875,
+    input                           cpu_clk, cpu_clk_enable,
     input                           rst,
 
     // video timing input
@@ -55,7 +56,7 @@ module background_m (
     wire in_pmb = ( address >= 12'h200 && address < 12'h400 );
     wire in_ntbl = ( address >= 12'h400 && address < 12'h800 );
 
-    always_ff @ ( posedge clk ) begin : write_to_vram
+    always_ff @ ( negedge cpu_clk ) if ( cpu_clk_enable ) begin : write_to_vram
         if ( write_enable && writable ) begin
             if ( in_pmb )
                 PMB[ address - 12'h200 ] <= data_in;

--- a/hardware-level/rtl/gpu/rtl/foreground.sv
+++ b/hardware-level/rtl/gpu/rtl/foreground.sv
@@ -14,7 +14,8 @@
 module foreground_m #(
     parameter NUM_OBJECTS = 64
 ) (
-    input                           clk, // 12.5875 MHz
+    input                           clk_12_5875,
+    input                           cpu_clk, cpu_clk_enable,
     input                           rst,
 
     // video timing input
@@ -52,7 +53,7 @@ module foreground_m #(
     wire in_pmf = ( address >= 12'h000 && address < 12'h200 );
     wire in_obm = ( address >= 12'h800 && address < 12'h900 );
 
-    always_ff @ ( posedge clk ) begin : write_to_vram
+    always_ff @ ( negedge cpu_clk ) if ( cpu_clk_enable ) begin : write_to_vram
         if ( write_enable && writable ) begin
             if ( in_pmf )
                 PMF[ address - 12'h000 ] <= data_in;

--- a/hardware-level/rtl/gpu/rtl/gpu.v
+++ b/hardware-level/rtl/gpu/rtl/gpu.v
@@ -16,7 +16,8 @@
 module gpu_m #(
         parameter FOREGROUND_NUM_OBJECTS = 64
 ) (
-    input                           clk, // 12.5875 MHz
+    input                           clk_12_5875,
+    input                           cpu_clk, cpu_clk_enable,
     input                           rst,
 
     // video output
@@ -43,7 +44,7 @@ module gpu_m #(
     reg writable_prev;
     initial writable_prev = 0;
 
-    always @ ( posedge clk ) begin
+    always @ ( posedge clk_12_5875 ) begin
 
         if ( write_enable && SELECT_clr_vblank_irq )
             vblank_irq <= 0;
@@ -74,7 +75,7 @@ module gpu_m #(
     assign current_y = vcounter[9:1];
 
     video_timing_m video_timing (
-        clk, rst,
+        clk_12_5875, rst,
         hsync, vsync,
         hcounter, vcounter,
         visible,
@@ -84,7 +85,7 @@ module gpu_m #(
     assign controller_start_fetch = ( hcounter < 10'd10 ) && ( vcounter == 10'b0 );
 
     foreground_m #(FOREGROUND_NUM_OBJECTS) foreground (
-        clk, rst,
+        clk_12_5875, cpu_clk, cpu_clk_enable, rst,
         current_x[7:0], current_y[7:0],
         writable,
         foreground_r, foreground_g, foreground_b,
@@ -93,7 +94,7 @@ module gpu_m #(
     );
 
     background_m background (
-        clk, rst,
+        clk_12_5875, cpu_clk,  cpu_clk_enable, rst,
         current_x[7:0], current_y[7:0],
         writable,
         background_r, background_g, background_b,

--- a/hardware-level/rtl/gpu/rtl/video-timing.v
+++ b/hardware-level/rtl/gpu/rtl/video-timing.v
@@ -6,7 +6,7 @@
 
 
 module video_timing_m (
-    input               clk, // 12.5875 MHz
+    input               clk_12_5875,
     input               rst,
 
     output wire         hsync, vsync,
@@ -16,6 +16,11 @@ module video_timing_m (
 
     output wire         writable
 );
+
+    initial begin
+        hcounter = 10'b0;
+        vcounter = 10'b0;
+    end
 
     wire hvisible, vvisible;
 
@@ -41,7 +46,7 @@ module video_timing_m (
     assign writable = ~vvisible;
 
 
-    always @ ( posedge clk ) begin
+    always @ ( posedge clk_12_5875 ) begin
         if ( rst ) begin
             hcounter <= 10'b0;
             vcounter <= 10'b0;

--- a/hardware-level/rtl/gpu/tests/fill_vram.sv
+++ b/hardware-level/rtl/gpu/tests/fill_vram.sv
@@ -9,7 +9,7 @@
 `endif
 
 module fill_vram_m (
-    input                               clk,
+    input                               clk_12_5875,
     input                               start,
 
     output reg                    [7:0] data,
@@ -21,7 +21,7 @@ module fill_vram_m (
 
     assign write_enable = in_progress;
 
-    always_ff @ ( posedge clk ) begin : increment_address
+    always_ff @ ( posedge clk_12_5875 ) begin : increment_address
         if ( start ) begin
             address = 12'b0;
             in_progress = 12'b1;

--- a/hardware-level/rtl/top/rtl/top.v
+++ b/hardware-level/rtl/top/rtl/top.v
@@ -13,7 +13,8 @@
 module top_m #(
     parameter FOREGROUND_NUM_OBJECTS = 64
 ) (
-    input               clk_12_5875, slow_clk, slow_clk_enable,
+    input               clk_12_5875,
+    input               cpu_clk, cpu_clk_enable,
     input               rst,
     input        [15:0] cpu_address,
     input         [7:0] data_in,
@@ -93,14 +94,14 @@ module top_m #(
 
     wire [11:0] gpu_address = ( cpu_address - 16'h3700 );
     gpu_m #(FOREGROUND_NUM_OBJECTS) gpu (
-        clk_12_5875, rst,
+        clk_12_5875, cpu_clk, cpu_clk_enable, rst,
         r,g,b, hsync, vsync, controller_start_fetch,
         data_in, gpu_data_out, gpu_address, write_enable, SELECT_vram,
         SELECT_in_vblank, SELECT_clr_vblank_irq, vblank_irq
     );
 
     controller_interface_m #(2) controller_interface (
-        slow_clk, slow_clk_enable, rst,
+        cpu_clk, cpu_clk_enable, rst,
         controller_start_fetch,
 
         controller_clk_enable,


### PR DESCRIPTION
The noise that appeared on the screen has been removed! It was thought to have been from unwanted inductance, but it was actually due to multiple clocking. The vram is now written only on `negedge cpu_clk`.

* [background.sv](https://github.com/ucsbieee/arcade/commit/c23614a7abf9e74824c6be0e6662a7bd12bbbe7f#diff-6ce7377b6851ab8c4dacf8223be19c474d34ef86003d946a1af3b2c8d7be61bbR59)
* [foreground.sv](https://github.com/ucsbieee/arcade/commit/c23614a7abf9e74824c6be0e6662a7bd12bbbe7f#diff-cedbb6c19099efd957598072fcbf8ecc0404aaf8f365ec65c2089ee2c22e354fR56)

Before:
![video_before](https://user-images.githubusercontent.com/43790149/129627242-c93b53cb-d8bb-4a4a-8724-569097a49665.jpg)

After:
![video_after](https://user-images.githubusercontent.com/43790149/132386584-2f1fc50d-e3d5-490a-b596-f4acd36b9a06.jpg)

---

Board:
![board](https://user-images.githubusercontent.com/43790149/129627237-8768c824-372a-488a-93ef-3037f8c854c7.jpg)