### PR TITLE
All 64 Objects Can be Rendered

### DIFF
--- a/assembly-level/src/tests/draw64.asm
+++ b/assembly-level/src/tests/draw64.asm
@@ -1,0 +1,363 @@
+
+; ====================== ;
+; ======= Header ======= ;
+; ====================== ;
+
+        .byte "Draw Demo\n"
+        .byte "You should see 64 objects.\n"
+        .byte 0
+
+
+; ====================== ;
+; ======= Labels ======= ;
+; ====================== ;
+
+
+; === Person === ;
+
+person_xp               = $87
+person_xv               = $89
+person_yp               = $8b
+person_yv               = $8d
+
+; constants
+person_xp_initial       = %0010000000000000     ; 128
+person_yp_initial       = %0010000000000000     ; 128
+
+
+
+; === VRAM Labels === ;
+
+; objects
+PERSON_O                = _OBM+0
+
+; PMF addresses
+NORMAL_PMFA             = 0
+LOOKING_UP_PMFA         = 1
+
+; sprite addresses
+NORMAL_S                = _PMF1 + NORMAL_PMFA * 16
+LOOKING_UP_S            = _PMF1 + LOOKING_UP_PMFA * 16
+
+; PMB addresses
+BLACK_PMBA              = 0
+DARK_GRAY_PMBA          = 1
+LIGHT_GRAY_PMBA         = 2
+WHITE_PMBA              = 3
+
+; tile addresses
+BLACK_T                 = _PMB1 + BLACK_PMBA * 16
+DARK_GRAY_T             = _PMB1 + DARK_GRAY_PMBA * 16
+LIGHT_GRAY_T            = _PMB1 + LIGHT_GRAY_PMBA * 16
+WHITE_T                 = _PMB1 + WHITE_PMBA * 16
+
+
+
+
+
+; ====================== ;
+; ===== Interrupts ===== ;
+; ====================== ;
+
+;==========================;
+        .org reset
+;==========================;
+        jsr person_initialize
+        rts
+
+
+
+
+
+;==========================;
+        .org do_logic
+;==========================;
+        rts
+
+
+
+
+
+;==========================;
+        .org fill_vram
+;==========================;
+        jsr vram_initialize
+
+STOP:
+        stp     ; Stop
+
+        rts
+
+
+
+
+
+; ====================== ;
+; ======== Logic ======= ;
+; ====================== ;
+
+
+
+
+
+
+person_initialize:
+        ldlab16 person_xp_initial, person_xp
+        ldlab16 person_yp_initial, person_yp
+        ldlab16 $0000, person_xv
+        ldlab16 $0000, person_yv
+        rts
+
+
+
+
+
+
+; ====================== ;
+; ======== VRAM ======== ;
+; ====================== ;
+
+vram_initialize:
+
+        ; initialize each section of VRAM
+        jsr pmf_initialize
+        jsr pmb_initialize
+        jsr ntbl_initialize
+        jsr obm_initialize
+        rts
+
+
+
+
+; set all object y positions to 0xff
+obm_clear:
+        ldlab16 _OBM, ADDRESS16_1
+        lda #$ff
+        ldy #0
+.loop
+        iny
+        sta (ADDRESS16_1),Y
+        iny
+        iny
+        iny
+        bne .loop
+
+        rts
+
+obm_initialize:
+
+.object_i       .set 0
+        .repeat 64
+.object         .set _OBM + .object_i*4
+.object_x       .set (.object_i << 3) & $ff
+.object_y       .set (.object_i/32)*8
+        ; set flip-modifiers and pattern
+        lda #0|NORMAL_PMFA
+        sta .object+2
+
+        ; set color
+        lda #%110
+        sta .object+3
+
+        ; load person_xp
+        lda #0|.object_x
+        sta .object
+
+        ; load person_yp
+        lda #0|.object_y
+        sta .object+1
+
+.object_i       .set .object_i+1
+        .endr
+        rts
+
+
+
+
+
+pmf_initialize:
+        ; sprites are 16 bytes
+        lda #16
+        sta INT8_I1
+
+        ; load NORMAL sprite
+        ldlab16 NORMAL_P, ADDRESS16_1
+        ldlab16 NORMAL_S, ADDRESS16_2
+        jsr transfer_mem
+
+        ; load LOOPING_UP sprite
+        ldlab16 LOOKING_UP_P, ADDRESS16_1
+        ldlab16 LOOKING_UP_S, ADDRESS16_2
+        jsr transfer_mem
+
+        rts
+
+
+
+
+
+pmb_initialize:
+        ; tiles are 16 bytes
+        lda #16
+        sta INT8_I1
+
+        ; load BLACK tile
+        ldlab16 BLACK_P, ADDRESS16_1
+        ldlab16 BLACK_T, ADDRESS16_2
+        jsr transfer_mem
+
+        ; load DARK_GRAY tile
+        ldlab16 DARK_GRAY_P, ADDRESS16_1
+        ldlab16 DARK_GRAY_T, ADDRESS16_2
+        jsr transfer_mem
+
+        ; load LIGHT_GRAY tile
+        ldlab16 LIGHT_GRAY_P, ADDRESS16_1
+        ldlab16 LIGHT_GRAY_T, ADDRESS16_2
+        jsr transfer_mem
+
+        ; load WHITE tile
+        ldlab16 WHITE_P, ADDRESS16_1
+        ldlab16 WHITE_T, ADDRESS16_2
+        jsr transfer_mem
+
+        rts
+
+
+
+
+
+
+
+
+
+ntbl_initialize:
+        ; set colors
+        lda #0|CYAN_C0|GREEN_C1
+        sta _NTBL_COLORS
+
+        ; load in scanlines
+        ; scalines are 32 bytes
+        lda #32
+        sta INT8_I1
+        ; set up incrementing by 32
+        ldlab16 32, INT16_I2
+        ldlab16 _NTBL1, INT16_O
+
+
+        ; sky
+        ldlab16 SKY_SCANLINE, ADDRESS16_1
+        lda #28
+        sta INT8_G1
+.sky_loop:
+        ; copy sky scanline to nametable
+        cp16 INT16_O, ADDRESS16_2
+        jsr transfer_mem
+
+        ; calculate next NTBL address
+        cp16 INT16_O, INT16_I1
+        jsr add16
+
+        dec INT8_G1
+        bne .sky_loop
+
+
+        ; ground
+        ldlab16 GROUND_SCANLINE, ADDRESS16_1
+        lda #2
+        sta INT8_G1
+.ground_loop:
+        ; copy sky scanline to nametable
+        cp16 INT16_O, ADDRESS16_2
+        jsr transfer_mem
+
+        ; calculate next NTBL address
+        cp16 INT16_O, INT16_I1
+        jsr add16
+
+        dec INT8_G1
+        bne .ground_loop
+
+
+        rts
+
+
+
+
+
+; ======== Patterns ======== ;
+
+PATTERN_START:
+
+BLACK_P:
+        .db $00, $00
+        .db $00, $00
+        .db $00, $00
+        .db $00, $00
+        .db $00, $00
+        .db $00, $00
+        .db $00, $00
+        .db $00, $00
+
+DARK_GRAY_P:
+        .db $55, $55
+        .db $55, $55
+        .db $55, $55
+        .db $55, $55
+        .db $55, $55
+        .db $55, $55
+        .db $55, $55
+        .db $55, $55
+
+LIGHT_GRAY_P:
+        .db $aa, $aa
+        .db $aa, $aa
+        .db $aa, $aa
+        .db $aa, $aa
+        .db $aa, $aa
+        .db $aa, $aa
+        .db $aa, $aa
+        .db $aa, $aa
+
+WHITE_P:
+        .db $ff, $ff
+        .db $ff, $ff
+        .db $ff, $ff
+        .db $ff, $ff
+        .db $ff, $ff
+        .db $ff, $ff
+        .db $ff, $ff
+        .db $ff, $ff
+
+NORMAL_P:
+        .db %00001010, %10100000
+        .db %00101111, %11111000
+        .db %00101111, %11111000
+        .db %10110111, %11011110
+        .db %10110111, %11011110
+        .db %10111111, %11111110
+        .db %00101111, %11111000
+        .db %00001010, %10100000
+
+LOOKING_UP_P:
+        .db %00001010, %10100000
+        .db %00101111, %11111000
+        .db %00101111, %11111000
+        .db %10111111, %11111110
+        .db %10110111, %11011110
+        .db %10110111, %11011110
+        .db %00101111, %11111000
+        .db %00001010, %10100000
+
+
+; ======== Nametable Data ======== ;
+
+SKY_SCANLINE:
+        .repeat 32
+        .db WHITE_PMBA
+        .endr
+
+GROUND_SCANLINE:
+        .repeat 32
+        .db LIGHT_GRAY_PMBA | COLOR_ALT
+        .endr

--- a/hardware-level/rtl/gpu/rtl/gpu.v
+++ b/hardware-level/rtl/gpu/rtl/gpu.v
@@ -84,9 +84,13 @@ module gpu_m #(
 
     wire vram_write_enable = writable & SELECT_vram & write_enable;
 
-    foreground_m #(FOREGROUND_NUM_OBJECTS) foreground (
+    foreground_m #(
+        .NUM_OBJECTS(FOREGROUND_NUM_OBJECTS),
+        .LINE_REPEAT(2),
+        .NUM_ROWS(523)
+    ) foreground (
         clk_12_5875, cpu_clk, cpu_clk_enable, rst,
-        current_x[7:0], current_y[7:0],
+        current_x, current_y, hsync,
         foreground_r, foreground_g, foreground_b,
         foreground_valid,
         data_in, address, vram_write_enable

--- a/hardware-level/rtl/top/sim/top.tb.v
+++ b/hardware-level/rtl/top/sim/top.tb.v
@@ -21,8 +21,8 @@ module top_tb_m ();
 
 reg clk_12_5875 = 1;
 always #( `GPU_CLK_PERIOD / 2 ) clk_12_5875 = ~clk_12_5875;
-reg clk_5 = 1;
-always #( `CPU_CLK_PERIOD / 10 ) clk_5 = ~clk_5;
+reg clk_1 = 1;
+always #( `CPU_CLK_PERIOD / 2 ) clk_1 = ~clk_1;
 
 wire            cpu_clk_enable;
 reg             rst;
@@ -54,18 +54,15 @@ reg       [7:0] write_data;
 assign data_in = write_data;
 assign data = fpga_data_enable ? data_out : data_in;
 
-clk_mask_m #(5) cpu_clk_mask (
-    clk_5, rst,
-    cpu_clk_enable
-);
+assign cpu_clk_enable = 1;
 
 clk_mask_m #(100) controller_clk_mask (
-    clk_5, rst,
+    clk_1, rst,
     controller_clk_in_enable
 );
 
 top_m top (
-    clk_12_5875, clk_5, cpu_clk_enable, rst,
+    clk_12_5875, clk_1, cpu_clk_enable, rst,
     cpu_address,
     data_in,
     data_out,
@@ -117,84 +114,38 @@ $dumpvars();
 $timeformat( -3, 6, "ms", 0);
 //\\ =========================== \\//
 
-controller_1_buttons_in = 8'b10001001;
-controller_2_buttons_in = 8'b00100110;
-
 rst = 1;
 #( 2*`CPU_CLK_PERIOD );
 rst = 0;
 
-@( negedge vsync );
+@(negedge vsync);
 
+@(posedge clk_1);
 write_enable_B = 0;
-cpu_address = 16'h3700;
-write_data = 8'b10011001;
-#( `CPU_CLK_PERIOD );
-
-cpu_address = 16'h3701;
-write_data = 8'b01000111;
-#( `CPU_CLK_PERIOD );
-
+@(posedge clk_1);
+for ( reg [7:0] i = 0; i < 16; i=i+1 ) begin
+    cpu_address = {8'h37,i};
+    write_data = i;
+    @(posedge clk_1);
+end
+// x
 cpu_address = 16'h3f00;
-write_data = 8'h00;
-#( `CPU_CLK_PERIOD );
+write_data = 8'b0;
+// y
+@(posedge clk_1);
 cpu_address = 16'h3f01;
-write_data = 8'h00;
-#( `CPU_CLK_PERIOD );
+write_data = 8'b0;
+// pmfa
+@(posedge clk_1);
 cpu_address = 16'h3f02;
-write_data = 8'bx00_00000;
-#( `CPU_CLK_PERIOD );
+write_data = 8'b0;
+// color
+@(posedge clk_1);
 cpu_address = 16'h3f03;
-write_data = 8'bxxxxx_100;
-#( `CPU_CLK_PERIOD );
+write_data = 8'b111;
 
-
-cpu_address = 16'h3900;
-write_data = 8'b11001100;
-#( `CPU_CLK_PERIOD );
-cpu_address = 16'h3901;
-write_data = 8'b01010101;
-#( `CPU_CLK_PERIOD );
-
-// cpu_address = 16'h3b00;
-// write_data = 8'b000_00000;
-// #( `CPU_CLK_PERIOD );
-cpu_address = 16'h3b01;
-write_data = 8'b100_00000;
-#( `CPU_CLK_PERIOD );
-
-
-cpu_address = 16'h3ec0;
-write_data = 8'bxx_010_101;
-#( `CPU_CLK_PERIOD );
-
-
-write_enable_B = 1;
-
-#( 16 * `CPU_CLK_PERIOD );
-// @( vsync );
-
-cpu_address = 16'h7002;
-#( `CPU_CLK_PERIOD );
-cpu_address = 16'h7003;
-#( `CPU_CLK_PERIOD );
-
-cpu_address = 16'h4000;
-#( `CPU_CLK_PERIOD );
-cpu_address = 16'h6fff;
-#( `CPU_CLK_PERIOD );
-
-cpu_address = 16'h8000;
-#( `CPU_CLK_PERIOD );
-cpu_address = 16'h9000;
-#( `CPU_CLK_PERIOD );
-
-cpu_address = 16'hfffa;
-#( `CPU_CLK_PERIOD );
-cpu_address = 16'hffff;
-#( `CPU_CLK_PERIOD );
-
-@( negedge vsync );
+@(negedge vsync);
+@(negedge vsync);
 
 
 //\\ =========================== \\//

--- a/hardware-level/rtl/top/synth/boards/cmod_a7/cmod_a7.v
+++ b/hardware-level/rtl/top/synth/boards/cmod_a7/cmod_a7.v
@@ -119,7 +119,7 @@ module cmod_a7 (
     wire [7:0] controller_1_buttons_out, controller_2_buttons_out;
 
     // module
-    top_m #(2) top (
+    top_m top (
         clk_12_5875, clk_5, cpu_clk_enable, rst,
         cpu_address,
         data_in,

--- a/hardware-level/rtl/top/synth/boards/cmod_a7/flash.xdc
+++ b/hardware-level/rtl/top/synth/boards/cmod_a7/flash.xdc
@@ -1,0 +1,3 @@
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+set_property BITSTREAM.CONFIG.CONFIGRATE 33 [current_design]
+set_property CONFIG_MODE SPIx4 [current_design]

--- a/hardware-level/rtl/top/top.core
+++ b/hardware-level/rtl/top/top.core
@@ -40,6 +40,7 @@ filesets:
       - synth/boards/cmod_a7/clk_mmcm_m.xci:  {file_type: xci}
       - synth/boards/cmod_a7/cmod_a7.xdc:     {file_type: xdc}
       - synth/boards/cmod_a7/cmod_a7.v:       {file_type: verilogSource}
+      - synth/boards/cmod_a7/flash.xdc:       {file_type: xdc}
     depend:
       - ucsbieee:arcade:clk_mask
 


### PR DESCRIPTION
## How it's done

The foreground processor now maintains 2 arrays:

* an array of all the OBMAs for each pixel in the current scanline
* an array of all the OBMAs for each pixel in the next scanline

On every scanline, it loads in the next scanline and draws the current scanline.

## Working Demo

[draw64.asm](https://github.com/ucsbieee/arcade/blob/7a305f/assembly-level/src/tests/draw64.asm)

![64_objects](https://user-images.githubusercontent.com/43790149/144326397-47091a52-46dd-4706-b9b7-881143b88c45.jpg)
